### PR TITLE
Update readiness check in Python SDK example

### DIFF
--- a/python-sdk-example/tests/integration/create_sandbox_test.py
+++ b/python-sdk-example/tests/integration/create_sandbox_test.py
@@ -82,20 +82,10 @@ class TestBasic(unittest.TestCase):
             raise RuntimeError("Endpoint `hotrod-route` missing")
         cls.endpoint_url = filtered_endpoints[0].url
 
-        sandbox_ready = False
-        max_attempts = 20
-        print("Checking sandbox readiness")
-        for i in range(1, max_attempts):
-            print("Attempt: {}/{}".format(i, max_attempts))
-            if sandbox.status.ready:
-                sandbox_ready = True
-                print("Sandbox is ready!")
-                break
+        # Code block to wait until sandbox is ready
+        while not sandbox.status.ready:
             time.sleep(5)
             sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, cls.sandbox_name)
-
-        if not sandbox_ready:
-            raise RuntimeError("Sandbox didn't get to Ready state")
 
     def test_valid_result(self):
         pickup = "123"

--- a/python-sdk-example/tests/integration/create_sandbox_test_with_custom_patch.py
+++ b/python-sdk-example/tests/integration/create_sandbox_test_with_custom_patch.py
@@ -95,20 +95,10 @@ class TestBasic(unittest.TestCase):
             raise RuntimeError("Endpoint `hotrod-customer` missing")
         cls.endpoint_url = filtered_endpoints[0].url
 
-        sandbox_ready = False
-        max_attempts = 20
-        print("Checking sandbox readiness")
-        for i in range(1, max_attempts):
-            print("Attempt: {}/{}".format(i, max_attempts))
-            if sandbox.status.ready:
-                sandbox_ready = True
-                print("Sandbox is ready!")
-                break
+        # Code block to wait until sandbox is ready
+        while not sandbox.status.ready:
             time.sleep(5)
             sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, cls.sandbox_name)
-
-        if not sandbox_ready:
-            raise RuntimeError("Sandbox didn't get to Ready state")
 
     def test_valid_result(self):
         service_url = "{}/customer?customer=392".format(self.endpoint_url)

--- a/python-sdk-example/tests/integration/create_sandbox_test_with_xref.py
+++ b/python-sdk-example/tests/integration/create_sandbox_test_with_xref.py
@@ -107,20 +107,10 @@ class TestBasic(unittest.TestCase):
             raise RuntimeError("Endpoint `hotrod-customer` missing")
         cls.endpoint_url = filtered_endpoints[0].url
 
-        sandbox_ready = False
-        max_attempts = 20
-        print("Checking sandbox readiness")
-        for i in range(1, max_attempts):
-            print("Attempt: {}/{}".format(i, max_attempts))
-            if sandbox.status.ready:
-                sandbox_ready = True
-                print("Sandbox is ready!")
-                break
+        # Code block to wait until sandbox is ready
+        while not sandbox.status.ready:
             time.sleep(5)
             sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, cls.sandbox_name)
-
-        if not sandbox_ready:
-            raise RuntimeError("Sandbox didn't get to Ready state")
 
     def test_valid_result(self):
         service_url = "{}/customer?customer=392".format(self.endpoint_url)

--- a/python-sdk-example/tests/integration/resources_test.py
+++ b/python-sdk-example/tests/integration/resources_test.py
@@ -110,20 +110,10 @@ class TestWithResources(unittest.TestCase):
             raise RuntimeError("Endpoint `customer-svc-endpoint` missing")
         cls.endpoint_url = filtered_endpoints[0].url
 
-        sandbox_ready = False
-        max_attempts = 20
-        print("Checking sandbox readiness")
-        for i in range(1, max_attempts):
-            print("Attempt: {}/{}".format(i, max_attempts))
-            if sandbox.status.ready:
-                sandbox_ready = True
-                print("Sandbox is ready!")
-                break
+        # Code block to wait until sandbox is ready
+        while not sandbox.status.ready:
             time.sleep(5)
             sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, cls.sandbox_name)
-
-        if not sandbox_ready:
-            raise RuntimeError("Sandbox didn't get to Ready state")
 
     def test_customer_service(self):
         service_url = "{}/customer?customer=999".format(self.endpoint_url)

--- a/python-sdk-example/tests/integration/usecase1_test.py
+++ b/python-sdk-example/tests/integration/usecase1_test.py
@@ -130,20 +130,9 @@ class TestUseCase1(unittest.TestCase):
         print("Frontend Service endpoint URL: {}".format(cls.endpoint_url))
 
         # Code block to wait until sandbox is ready
-        sandbox_ready = False
-        max_attempts = 20
-        print("Checking sandbox readiness")
-        for i in range(1, max_attempts):
-            print("Attempt: {}/{}".format(i, max_attempts))
-            if sandbox.status.ready:
-                sandbox_ready = True
-                print("Sandbox is ready!")
-                break
+        while not sandbox.status.ready:
             time.sleep(5)
             sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, cls.sandbox_name)
-
-        if not sandbox_ready:
-            raise RuntimeError("Sandbox didn't get to Ready state")
 
     def test_frontend(self):
         # Run tests on the updated frontend service using the endpoint URL

--- a/python-sdk-example/tests/integration/usecase2_test.py
+++ b/python-sdk-example/tests/integration/usecase2_test.py
@@ -154,20 +154,9 @@ class TestUseCase2(unittest.TestCase):
         print("Frontend Service endpoint URL: {}".format(cls.endpoint_url))
 
         # Code block to wait until sandbox is ready
-        sandbox_ready = False
-        max_attempts = 20
-        print("Checking sandbox readiness")
-        for i in range(1, max_attempts):
-            print("Attempt: {}/{}".format(i, max_attempts))
-            if sandbox.status.ready:
-                sandbox_ready = True
-                print("Sandbox is ready!")
-                break
+        while not sandbox.status.ready:
             time.sleep(5)
             sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, cls.sandbox_name)
-
-        if not sandbox_ready:
-            raise RuntimeError("Sandbox didn't get to Ready state")
 
     def test_frontend(self):
         # Run tests on the updated frontend service using the endpoint URL


### PR DESCRIPTION
Checking for readiness in a loop, bound only by timeout and not by number of attempts. Made the change in Java and Node examples earlier, but had forgotten for Python.