### PR TITLE
[Java+Python] SDK examples updated to use SDK v0.3.6. New examples for RouteGroups

### DIFF
--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'io.rest-assured:rest-assured:5.0.1'
     testImplementation 'org.testng:testng:7.5'
-    testImplementation 'com.signadot:signadot-sdk:0.3.5'
+    testImplementation 'com.signadot:signadot-sdk:0.3.6'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 

--- a/sdk/java/src/test/java/CreateSandboxTest.java
+++ b/sdk/java/src/test/java/CreateSandboxTest.java
@@ -39,18 +39,20 @@ public class CreateSandboxTest {
       apiClient.setApiKey(SIGNADOT_API_KEY);
       sandboxesApi = new SandboxesApi(apiClient);
 
-      sandboxName = String.format("test-ws-%s", RandomStringUtils.randomAlphanumeric(5));
+      sandboxName = String.format("test-ws-%s", RandomStringUtils.randomNumeric(5));
 
       SandboxFork routeFork = new SandboxFork()
         .forkOf(new SandboxForkOf().kind("Deployment").namespace(HOTROD).name("route"))
         .customizations(new SandboxCustomizations()
           .addEnvItem(new SandboxEnvVar().name("abc").value("def"))
-          .addImagesItem(new SandboxImage().image("signadot/hotrod:0ed0bdadaa3af1e4f1e6f3bb6b7d19504aa9b1bd")))
-        .addEndpointsItem(new SandboxForkEndpoint().name("hotrod-route").port(8083).protocol("http"));
+          .addImagesItem(new SandboxImage().image("signadot/hotrod:0ed0bdadaa3af1e4f1e6f3bb6b7d19504aa9b1bd")));
 
       Map<String, String> labels = new HashMap<>();
       labels.put("key1", "value1");
       labels.put("key2", "value2");
+
+      SandboxDefaultRouteGroup drg = new SandboxDefaultRouteGroup()
+        .addEndpointsItem(new RouteGroupSpecEndpoint().name("hotrod-route").target("http://route.hotrod.deploy:8083"));
 
       Sandbox request = new Sandbox()
         .spec(new SandboxSpec()
@@ -58,7 +60,8 @@ public class CreateSandboxTest {
           .cluster(CLUSTER_NAME)
           .ttl(new SandboxTTL().duration("10m"))
           .description("Java SDK: sandbox creation example")
-          .addForksItem(routeFork));
+          .addForksItem(routeFork)
+          .defaultRouteGroup(drg));
 
       sandbox = sandboxesApi.applySandbox(ORG_NAME, sandboxName, request);
 

--- a/sdk/java/src/test/java/CreateSandboxWithCustomPatchTest.java
+++ b/sdk/java/src/test/java/CreateSandboxWithCustomPatchTest.java
@@ -56,21 +56,24 @@ public class CreateSandboxWithCustomPatchTest {
     try {
       envVarValue = RandomStringUtils.randomAlphanumeric(5);
       final String customPatch = String.format(CUSTOM_PATCH, envVarValue);
-      sandboxName = String.format("custom-patch-test-%s", RandomStringUtils.randomAlphanumeric(5));
+      sandboxName = String.format("custom-patch-test-%s", RandomStringUtils.randomNumeric(5));
 
       SandboxFork customerFork = new SandboxFork()
         .forkOf(new SandboxForkOf().kind("Deployment").namespace(HOTROD).name("customer"))
         .customizations(new SandboxCustomizations()
           .addImagesItem(new SandboxImage().image(HOTROD_TEST_IMAGE))
-          .patch(new SandboxCustomPatch().type("strategic").value(customPatch)))
-        .addEndpointsItem(new SandboxForkEndpoint().name("hotrod-customer").port(8081).protocol("http"));
+          .patch(new SandboxCustomPatch().type("strategic").value(customPatch)));
+
+      SandboxDefaultRouteGroup drg = new SandboxDefaultRouteGroup()
+        .addEndpointsItem(new RouteGroupSpecEndpoint().name("hotrod-customer").target("http://customer.hotrod.deploy:8081"));
 
       Sandbox request = new Sandbox()
         .spec(new SandboxSpec()
           .cluster(CLUSTER_NAME)
           .ttl(new SandboxTTL().duration("10m"))
           .description("Java SDK: sandbox creation with custom patch example")
-          .addForksItem(customerFork));
+          .addForksItem(customerFork)
+          .defaultRouteGroup(drg));
 
       sandbox = sandboxesApi.applySandbox(ORG_NAME, sandboxName, request);
 

--- a/sdk/java/src/test/java/CreateSandboxWithXRefTest.java
+++ b/sdk/java/src/test/java/CreateSandboxWithXRefTest.java
@@ -47,7 +47,7 @@ public class CreateSandboxWithXRefTest {
       apiClient.setApiKey(SIGNADOT_API_KEY);
       sandboxesApi = new SandboxesApi(apiClient);
 
-      sandboxName = String.format("xref-test-%s", RandomStringUtils.randomAlphanumeric(5));
+      sandboxName = String.format("xref-test-%s", RandomStringUtils.randomNumeric(5));
 
       SandboxFork frontendFork = new SandboxFork()
         .forkOf(new SandboxForkOf().kind("Deployment").namespace(HOTROD).name("frontend"))
@@ -69,8 +69,10 @@ public class CreateSandboxWithXRefTest {
               ).expression("{{ .Service.Host }}:{{ .Service.Port }}")
             )
           ))
-        )
-        .addEndpointsItem(new SandboxForkEndpoint().name("hotrod-customer").port(8081).protocol("http"));
+        );
+
+      SandboxDefaultRouteGroup drg = new SandboxDefaultRouteGroup()
+        .addEndpointsItem(new RouteGroupSpecEndpoint().name("hotrod-customer").target("http://customer.hotrod.deploy:8081"));
 
       Sandbox request = new Sandbox()
         .spec(new SandboxSpec()
@@ -78,7 +80,8 @@ public class CreateSandboxWithXRefTest {
           .ttl(new SandboxTTL().duration("10m"))
           .description("Java SDK: sandbox creation with cross fork reference example")
           .addForksItem(customerFork)
-          .addForksItem(frontendFork));
+          .addForksItem(frontendFork)
+          .defaultRouteGroup(drg));
 
       sandbox = sandboxesApi.applySandbox(ORG_NAME, sandboxName, request);
 

--- a/sdk/java/src/test/java/ResourcesTest.java
+++ b/sdk/java/src/test/java/ResourcesTest.java
@@ -54,7 +54,7 @@ public class ResourcesTest {
     sandboxesApi = new SandboxesApi(apiClient);
 
     try {
-      sandboxName = String.format("db-resource-test-%s", RandomStringUtils.randomAlphanumeric(5));
+      sandboxName = String.format("db-resource-test-%s", RandomStringUtils.randomNumeric(5));
 
       SandboxFork customerServiceFork = new SandboxFork()
         .forkOf(new SandboxForkOf().kind("Deployment").namespace(HOTROD).name("customer"))
@@ -71,13 +71,15 @@ public class ResourcesTest {
               ))
             )
           )
-          .addImagesItem(new SandboxImage().image("signadot/hotrod:cace2c797082481ac0238cc1310b7816980e3244")))
-        .addEndpointsItem(new SandboxForkEndpoint().name("customer-svc-endpoint").port(8081).protocol("http"));
+          .addImagesItem(new SandboxImage().image("signadot/hotrod:cace2c797082481ac0238cc1310b7816980e3244")));
 
       SandboxResource customerDBResource = new SandboxResource()
         .name("customerdb")
         .plugin("hotrod-mariadb")
         .putParamsItem("dbname", "customer");
+
+      SandboxDefaultRouteGroup drg = new SandboxDefaultRouteGroup()
+        .addEndpointsItem(new RouteGroupSpecEndpoint().name("customer-svc-endpoint").target("http://customer.hotrod.deploy:8081"));
 
       Sandbox request = new Sandbox()
         .spec(new SandboxSpec()
@@ -85,7 +87,8 @@ public class ResourcesTest {
           .ttl(new SandboxTTL().duration("10m"))
           .description("Java SDK: Create sandbox with ephemeral db resource spun up using hotrod-mariadb plugin")
           .addForksItem(customerServiceFork)
-          .addResourcesItem(customerDBResource));
+          .addResourcesItem(customerDBResource)
+          .defaultRouteGroup(drg));
 
       sandbox = sandboxesApi.applySandbox(ORG_NAME, sandboxName, request);
 

--- a/sdk/java/src/test/java/RouteGroupTest.java
+++ b/sdk/java/src/test/java/RouteGroupTest.java
@@ -1,0 +1,175 @@
+import com.signadot.ApiClient;
+import com.signadot.ApiException;
+import com.signadot.api.RouteGroupsApi;
+import com.signadot.api.SandboxesApi;
+import com.signadot.model.*;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * This test creates a sandbox, and a routegroup matching the sandbox by labels, and verifies that the routegroup
+ * endpoint reflects the changes introduced by the sandbox.
+ *
+ * Sandbox:
+ * The sandbox spec contains the below customization:
+ * - forks the frontend service, applying the image - `signadot/hotrod-e2e:latest`. This includes the frontend service
+ *    change to return the text 'Hot R.O.D. (e2e-test)'.
+ * - Applies the label: `feature: <random value>`
+ *
+ * Routegroup:
+ * The routegroup spec contains the below customization:
+ * - rule to match by label: `feature: <random value from the sandbox spec above>`
+ * - endpoint to frontend service (target: http://frontend.hotrod.svc:8080)
+ *
+ * Test:
+ * We consume the routegroup endpoint (to the frontend service), and verify that the response (HTML) contains the
+ * text 'Hot R.O.D. (e2e-test)'.
+ */
+public class RouteGroupTest {
+
+  private static final int TIMEOUT = 120000;
+  public static final String HOTROD = "hotrod";
+  public static final String ORG_NAME = System.getenv("SIGNADOT_ORG");
+  public static final String SIGNADOT_API_KEY = System.getenv("SIGNADOT_API_KEY");
+  public static final String CLUSTER_NAME = System.getenv("SIGNADOT_CLUSTER_NAME");
+
+  RequestSpecification requestSpec;
+  SandboxesApi sandboxesApi;
+  RouteGroupsApi routeGroupsApi;
+  Sandbox sb;
+  RouteGroup rg;
+
+  @BeforeSuite(timeOut = TIMEOUT)
+  public void setup() throws InterruptedException, ApiException {
+    ApiClient apiClient = new ApiClient();
+    apiClient.setApiKey(SIGNADOT_API_KEY);
+    sandboxesApi = new SandboxesApi(apiClient);
+    routeGroupsApi = new RouteGroupsApi(apiClient);
+
+    String labelKey = "feature";
+    String lavelValue = RandomStringUtils.randomNumeric(5);
+
+    sb = createSandbox(labelKey, lavelValue);
+    rg = createRouteGroup(labelKey, lavelValue);
+
+    List<RouteGroupEndpoint> endpoints = rg.getEndpoints();
+    if (endpoints.size() == 0) {
+      throw new RuntimeException("routegroup endpoints expected but not found");
+    }
+
+    RouteGroupEndpoint endpoint = null;
+    for (RouteGroupEndpoint ep : endpoints) {
+      if ("frontend-ep".equals(ep.getName())) {
+        endpoint = ep;
+        break;
+      }
+    }
+    if (endpoint == null) {
+      throw new RuntimeException("No routegroup endpoint found for the frontend service");
+    }
+
+    // set the base URL for tests
+    RestAssured.baseURI = endpoint.getUrl();
+
+    RequestSpecBuilder builder = new RequestSpecBuilder();
+    builder.setBaseUri(RestAssured.baseURI);
+    builder.addHeader("signadot-api-key", SIGNADOT_API_KEY);
+
+    requestSpec = builder.build();
+  }
+
+  public Sandbox createSandbox(final String labelKey, final String labelValue) {
+    try {
+      String sandboxName = String.format("test-ws-%s", RandomStringUtils.randomNumeric(5));
+
+      SandboxFork frontendFork = new SandboxFork()
+        .forkOf(new SandboxForkOf().kind("Deployment").namespace(HOTROD).name("frontend"))
+        .customizations(new SandboxCustomizations()
+          .addImagesItem(new SandboxImage().image("signadot/hotrod-e2e:latest")));
+
+      Map<String, String> labels = new HashMap<>();
+      labels.put(labelKey, labelValue);
+
+      Sandbox request = new Sandbox()
+        .spec(new SandboxSpec()
+          .labels(labels)
+          .cluster(CLUSTER_NAME)
+          .ttl(new SandboxTTL().duration("10m"))
+          .description("Java SDK: sandbox for routegroup test")
+          .addForksItem(frontendFork));
+
+      Sandbox sandbox = sandboxesApi.applySandbox(ORG_NAME, sandboxName, request);
+
+      // Check for sandbox readiness
+      while (!sandbox.getStatus().isReady()) {
+        Thread.sleep(5000);
+        sandbox = sandboxesApi.getSandbox(ORG_NAME, sandboxName);
+      }
+      return sandbox;
+    } catch (ApiException e) {
+      System.out.println(e.getResponseBody());
+      e.printStackTrace();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  public RouteGroup createRouteGroup(final String labelKey, final String labelValue) throws ApiException, InterruptedException {
+    try {
+      String name = String.format("test-rg-%s", RandomStringUtils.randomNumeric(5));
+
+      RouteGroup request = new RouteGroup()
+        .name("java-sdk-test-rg")
+        .spec(
+          new RouteGroupSpec()
+            .cluster(CLUSTER_NAME)
+            .match(new RouteGroupMatch().label(new RouteGroupMatchLabel().key(labelKey).value(labelValue)))
+            .addEndpointsItem(new RouteGroupSpecEndpoint().name("frontend-ep").target("http://frontend.hotrod.svc:8080")));
+
+      RouteGroup routegroup = routeGroupsApi.applyRoutegroup(ORG_NAME, name, request);
+
+      // Check for routegroup readiness
+      while (!routegroup.getStatus().isReady()) {
+        Thread.sleep(5000);
+        routegroup = routeGroupsApi.getRoutegroup(ORG_NAME, name);
+      }
+
+      return routegroup;
+    } catch (ApiException e) {
+      System.out.println(e.getResponseBody());
+      e.printStackTrace();
+      throw e;
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+  @Test
+  public void testFrontendChange() {
+    given().
+      spec(requestSpec).
+      when().
+      get("/").
+      then().
+      statusCode(200).
+      assertThat().body(containsString("Hot R.O.D. (e2e-test)"));
+  }
+
+  @AfterSuite
+  public void deleteSandbox() throws ApiException {
+    sandboxesApi.deleteSandbox(ORG_NAME, sb.getName());
+    routeGroupsApi.deleteRoutegroup(ORG_NAME, rg.getName());
+  }
+}

--- a/sdk/python/test-requirements.txt
+++ b/sdk/python/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.2.5
-signadot-sdk==0.3.5
+signadot-sdk==0.3.6
 requests==2.27.1
 timeout_decorator==0.5.0

--- a/sdk/python/tests/integration/create_sandbox_test.py
+++ b/sdk/python/tests/integration/create_sandbox_test.py
@@ -8,9 +8,9 @@ import unittest
 
 import requests
 import timeout_decorator
-
 from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
-    SandboxCustomizations, SandboxImage, SandboxForkEndpoint, SandboxEnvVar, Sandbox, SandboxSpec, SandboxTTL
+    SandboxCustomizations, SandboxImage, SandboxEnvVar, Sandbox, SandboxSpec, SandboxTTL, \
+    SandboxDefaultRouteGroup, RouteGroupSpecEndpoint
 from signadot_sdk.rest import ApiException
 
 
@@ -55,14 +55,7 @@ class TestBasic(unittest.TestCase):
                 env=[
                     SandboxEnvVar(name="abc", value="xyz")
                 ]
-            ),
-            endpoints=[
-                SandboxForkEndpoint(
-                    name="hotrod-route",
-                    port=8083,
-                    protocol="http"
-                )
-            ]
+            )
         )
         cls.sandbox_name = "test-ws-{}".format(get_random_string(5))
         request = Sandbox(
@@ -71,7 +64,12 @@ class TestBasic(unittest.TestCase):
                 description="Sample sandbox created using Python SDK",
                 ttl=SandboxTTL(duration="10m"),
                 cluster=cls.SIGNADOT_CLUSTER_NAME,
-                forks=[route_fork]
+                forks=[route_fork],
+                default_route_group=SandboxDefaultRouteGroup(
+                    endpoints=[
+                        RouteGroupSpecEndpoint(name="hotrod-route", target="http://route.hotrod.deploy:8083")
+                    ]
+                )
             )
         )
 

--- a/sdk/python/tests/integration/create_sandbox_test_with_custom_patch.py
+++ b/sdk/python/tests/integration/create_sandbox_test_with_custom_patch.py
@@ -8,9 +8,9 @@ import unittest
 
 import requests
 import timeout_decorator
-
 from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
-    SandboxCustomizations, SandboxImage, SandboxForkEndpoint, Sandbox, SandboxSpec, SandboxCustomPatch, SandboxTTL
+    SandboxCustomizations, SandboxImage, Sandbox, SandboxSpec, SandboxCustomPatch, SandboxTTL, \
+    SandboxDefaultRouteGroup, RouteGroupSpecEndpoint
 from signadot_sdk.rest import ApiException
 
 
@@ -68,14 +68,7 @@ class TestBasic(unittest.TestCase):
                     type="strategic",
                     value=cls.CUSTOM_PATCH.format(cls.env_var_value)
                 )
-            ),
-            endpoints=[
-                SandboxForkEndpoint(
-                    name="hotrod-customer",
-                    port=8081,
-                    protocol="http"
-                )
-            ]
+            )
         )
         cls.sandbox_name = "custom-patch-test-{}".format(get_random_string(5))
         request = Sandbox(
@@ -83,7 +76,12 @@ class TestBasic(unittest.TestCase):
                 description="Python SDK: sandbox creation with custom patch example",
                 ttl=SandboxTTL(duration="10m"),
                 cluster=cls.CLUSTER_NAME,
-                forks=[customer_fork]
+                forks=[customer_fork],
+                default_route_group=SandboxDefaultRouteGroup(
+                    endpoints=[
+                        RouteGroupSpecEndpoint(name="hotrod-customer", target="http://customer.hotrod.deploy:8081")
+                    ]
+                )
             )
         )
 

--- a/sdk/python/tests/integration/create_sandbox_test_with_xref.py
+++ b/sdk/python/tests/integration/create_sandbox_test_with_xref.py
@@ -8,10 +8,9 @@ import unittest
 
 import requests
 import timeout_decorator
-
 from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
-    SandboxCustomizations, SandboxImage, SandboxForkEndpoint, SandboxEnvVar, Sandbox, SandboxSpec, SandboxEnvValueFrom, \
-    SandboxEnvValueFromFork, SandboxTTL
+    SandboxCustomizations, SandboxImage, SandboxEnvVar, Sandbox, SandboxSpec, SandboxEnvValueFrom, \
+    SandboxEnvValueFromFork, SandboxTTL, SandboxDefaultRouteGroup, RouteGroupSpecEndpoint
 from signadot_sdk.rest import ApiException
 
 
@@ -79,14 +78,7 @@ class TestBasic(unittest.TestCase):
                         )
                     )
                 ]
-            ),
-            endpoints=[
-                SandboxForkEndpoint(
-                    name="hotrod-customer",
-                    port=8081,
-                    protocol="http"
-                )
-            ]
+            )
         )
         cls.sandbox_name = "xref-test-{}".format(get_random_string(5))
         request = Sandbox(
@@ -94,7 +86,12 @@ class TestBasic(unittest.TestCase):
                 description="Python SDK: sandbox creation with cross-fork reference example",
                 ttl=SandboxTTL(duration="10m"),
                 cluster=cls.CLUSTER_NAME,
-                forks=[customer_fork, frontend_fork]
+                forks=[customer_fork, frontend_fork],
+                default_route_group=SandboxDefaultRouteGroup(
+                    endpoints=[
+                        RouteGroupSpecEndpoint(name="hotrod-customer", target="http://customer.hotrod.deploy:8081")
+                    ]
+                )
             )
         )
 

--- a/sdk/python/tests/integration/resources_test.py
+++ b/sdk/python/tests/integration/resources_test.py
@@ -8,10 +8,9 @@ import unittest
 
 import requests
 import timeout_decorator
-
 from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
-    SandboxCustomizations, SandboxImage, SandboxForkEndpoint, SandboxEnvVar, Sandbox, SandboxSpec, SandboxEnvValueFrom, \
-    SandboxEnvValueFromResource, SandboxResource, SandboxTTL
+    SandboxCustomizations, SandboxImage, SandboxEnvVar, Sandbox, SandboxSpec, SandboxEnvValueFrom, \
+    SandboxEnvValueFromResource, SandboxResource, SandboxTTL, SandboxDefaultRouteGroup, RouteGroupSpecEndpoint
 from signadot_sdk.rest import ApiException
 
 
@@ -86,8 +85,7 @@ class TestWithResources(unittest.TestCase):
                         )
                     )
                 ]
-            ),
-            endpoints=[SandboxForkEndpoint(name="customer-svc-endpoint", port=8081, protocol="http")]
+            )
         )
 
         cls.sandbox_name = "db-resource-test-{}".format(get_random_string(5))
@@ -98,7 +96,12 @@ class TestWithResources(unittest.TestCase):
                 ttl=SandboxTTL(duration="10m"),
                 resources=[SandboxResource(name="customerdb", plugin="hotrod-mariadb",
                                            params={"dbname": "customer"})],
-                forks=[customer_service_fork]
+                forks=[customer_service_fork],
+                default_route_group=SandboxDefaultRouteGroup(
+                    endpoints=[
+                        RouteGroupSpecEndpoint(name="customer-svc-endpoint", target="http://customer.hotrod.deploy:8081")
+                    ]
+                )
             )
         )
 

--- a/sdk/python/tests/integration/routegroup_test.py
+++ b/sdk/python/tests/integration/routegroup_test.py
@@ -1,0 +1,135 @@
+from __future__ import print_function
+
+import os
+import random
+import string
+import time
+import unittest
+
+import requests
+import timeout_decorator
+from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
+    SandboxCustomizations, SandboxImage, Sandbox, SandboxSpec, SandboxTTL, \
+    RouteGroupSpecEndpoint, RouteGroup, RouteGroupSpec, RouteGroupMatch, RouteGroupMatchLabel, \
+    RouteGroupsApi
+
+
+def get_random_string(length):
+    return ''.join(random.choice(string.ascii_lowercase + string.digits) for i in range(length))
+
+
+"""
+This test creates a sandbox, and a routegroup matching the sandbox by labels, and verifies that the routegroup
+endpoint reflects the changes introduced by the sandbox.
+
+Sandbox:
+The sandbox spec contains the below customization:
+- forks the frontend service, applying the image - `signadot/hotrod-e2e:latest`. This includes the frontend service
+   change to return the text 'Hot R.O.D. (e2e-test)'.
+- Applies the label: `feature: <random value>`
+
+Routegroup:
+The routegroup spec contains the below customization:
+- rule to match by label: `feature: <random value from the sandbox spec above>`
+- endpoint to frontend service (target: http://frontend.hotrod.svc:8080)
+
+Test:
+We consume the routegroup endpoint (to the frontend service), and verify that the response (HTML) contains the
+text 'Hot R.O.D. (e2e-test)'.
+"""
+
+
+class TestRouteGroups(unittest.TestCase):
+    SIGNADOT_CLUSTER_NAME = os.getenv('SIGNADOT_CLUSTER_NAME')
+    if SIGNADOT_CLUSTER_NAME is None:
+        raise OSError("SIGNADOT_CLUSTER_NAME is not set")
+
+    SIGNADOT_ORG = os.getenv('SIGNADOT_ORG')
+    if SIGNADOT_ORG is None:
+        raise OSError("SIGNADOT_ORG is not set")
+
+    SIGNADOT_API_KEY = os.getenv('SIGNADOT_API_KEY')
+    if SIGNADOT_API_KEY is None:
+        raise OSError("SIGNADOT_API_KEY is not set")
+
+    configuration = Configuration()
+    configuration.api_key['signadot-api-key'] = SIGNADOT_API_KEY
+
+    api_client = ApiClient(configuration)
+    sandboxes_api = SandboxesApi(api_client)
+    routegroups_api = RouteGroupsApi(api_client)
+    headers_dict = {"signadot-api-key": SIGNADOT_API_KEY}
+
+    sandbox = None
+    routegroup = None
+
+    @classmethod
+    @timeout_decorator.timeout(120)
+    def setUpClass(cls):
+        labelKey = "feature"
+        labelValue = get_random_string(5)
+        cls.sandbox = cls.createSandbox(labelKey, labelValue)
+        cls.routegroup = cls.createRouteGroup(labelKey, labelValue)
+
+        filtered_endpoints = list(filter(lambda ep: ep.name == "frontend-ep", cls.routegroup.endpoints))
+        if len(filtered_endpoints) == 0:
+            raise RuntimeError("Endpoint `frontend-ep` missing in routegroup")
+        cls.endpoint_url = filtered_endpoints[0].url
+
+    @classmethod
+    def createSandbox(cls, labelKey, labelValue):
+        frontend_fork = SandboxFork(
+            fork_of=SandboxForkOf(kind="Deployment", name="frontend", namespace="hotrod"),
+            customizations=SandboxCustomizations(images=[SandboxImage(image="signadot/hotrod-e2e:latest")]))
+
+        sandbox_name = "rg-test-{}".format(get_random_string(5))
+        request = Sandbox(
+            spec=SandboxSpec(
+                labels={labelKey: labelValue},
+                description="Created using Python SDK to test RouteGroups",
+                ttl=SandboxTTL(duration="10m"),
+                cluster=cls.SIGNADOT_CLUSTER_NAME,
+                forks=[frontend_fork]))
+
+        sandbox = cls.sandboxes_api.apply_sandbox(cls.SIGNADOT_ORG, sandbox_name, request)
+
+        # Code block to wait until sandbox is ready
+        while not sandbox.status.ready:
+            time.sleep(5)
+            sandbox = cls.sandboxes_api.get_sandbox(cls.SIGNADOT_ORG, sandbox_name)
+        return sandbox
+
+    @classmethod
+    def createRouteGroup(cls, labelKey, labelValue):
+        routegroup_name = "test-rg-{}".format(get_random_string(5))
+        request = RouteGroup(
+            spec=RouteGroupSpec(
+                cluster=cls.SIGNADOT_CLUSTER_NAME,
+                description="Created using Python SDK to test RouteGroups",
+                match=RouteGroupMatch(label=RouteGroupMatchLabel(key=labelKey, value=labelValue)),
+                endpoints=[RouteGroupSpecEndpoint(name="frontend-ep", target="http://frontend.hotrod.svc:8080")]))
+
+        routegroup = cls.routegroups_api.apply_routegroup(cls.SIGNADOT_ORG, routegroup_name, request)
+
+        # Code block to wait until routegroup is ready
+        while not routegroup.status.ready:
+            time.sleep(5)
+            routegroup = cls.routegroups_api.get_routegroup(cls.SIGNADOT_ORG, routegroup_name)
+        return routegroup
+
+    def test_frontend_change(self):
+        response = requests.get(self.endpoint_url, headers=self.headers_dict)
+        response.raise_for_status()
+        html = response.content.decode("utf-8")
+
+        expected_content = "Hot R.O.D. (e2e-test)"
+        self.assertTrue(expected_content in html)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sandboxes_api.delete_sandbox(cls.SIGNADOT_ORG, cls.sandbox.name)
+        cls.routegroups_api.delete_routegroup(cls.SIGNADOT_ORG, cls.routegroup.name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/tests/integration/usecase1_test.py
+++ b/sdk/python/tests/integration/usecase1_test.py
@@ -8,7 +8,8 @@ import unittest
 
 import timeout_decorator
 from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
-    SandboxCustomizations, SandboxImage, SandboxEnvVar, Sandbox, SandboxSpec, SandboxHostEndpoint, SandboxTTL
+    SandboxCustomizations, SandboxImage, SandboxEnvVar, Sandbox, SandboxSpec, SandboxHostEndpoint, SandboxTTL, \
+    SandboxDefaultRouteGroup, RouteGroupSpecEndpoint
 from signadot_sdk.rest import ApiException
 
 """
@@ -89,19 +90,7 @@ class TestUseCase1(unittest.TestCase):
                 env=[
                     SandboxEnvVar(name="abc", value="xyz")
                 ]
-            ),
-            # Since we are only interested in previewing the change to the Route service through the frontend, we do not
-            # need an endpoint to the fork-of Route service.
-            endpoints=None
-        )
-
-        # Define an additional endpoint to the frontend service as we're interested in testing the Route service
-        # changes through the frontend service.
-        frontend_endpoint = SandboxHostEndpoint(
-            host="frontend.hotrod.svc",  # Host for frontend service
-            name="hotrod-frontend",  # Name for the endpoint
-            port=8080,  # Frontend service operates on port 8080
-            protocol="http"  # Frontend service uses HTTP protocol
+            )
         )
 
         cls.sandbox_name = "test-ws-{}".format(get_random_string(5))
@@ -109,11 +98,15 @@ class TestUseCase1(unittest.TestCase):
         # endpoint to frontend service.
         request = Sandbox(
             spec=SandboxSpec(
-                description="Sample sandbox created using Python SDK",
+                description="Sample sandbox created using Python SDK (use case 1)",
                 cluster=cls.SIGNADOT_CLUSTER_NAME,
                 ttl=SandboxTTL(duration="10m"),
                 forks=[route_fork],
-                endpoints=[frontend_endpoint]
+                default_route_group=SandboxDefaultRouteGroup(
+                    endpoints=[
+                        RouteGroupSpecEndpoint(name="hotrod-frontend", target="http://frontend.hotrod.svc:8080")
+                    ]
+                )
             )
         )
 

--- a/sdk/python/tests/integration/usecase2_test.py
+++ b/sdk/python/tests/integration/usecase2_test.py
@@ -8,7 +8,8 @@ import unittest
 
 import timeout_decorator
 from signadot_sdk import Configuration, SandboxesApi, ApiClient, SandboxFork, SandboxForkOf, \
-    SandboxCustomizations, SandboxImage, SandboxForkEndpoint, SandboxEnvVar, Sandbox, SandboxSpec, SandboxTTL
+    SandboxCustomizations, SandboxImage, SandboxEnvVar, Sandbox, SandboxSpec, SandboxTTL, \
+    SandboxDefaultRouteGroup, RouteGroupSpecEndpoint
 from signadot_sdk.rest import ApiException
 
 """
@@ -119,26 +120,22 @@ class TestUseCase2(unittest.TestCase):
                 env=[
                     SandboxEnvVar(name="pqr", value="stu")
                 ]
-            ),
-            # Spec to create an endpoint to fork (of frontend service) serving HTTP traffic on port 8080. This requires
-            # a name (valid name can include alphabet, numbers and hyphens, and starts with an alphabet).
-            endpoints=[
-                SandboxForkEndpoint(
-                    name="hotrod-frontend",
-                    port=8080,
-                    protocol="http"
-                )
-            ]
+            )
         )
 
         cls.sandbox_name = "test-ws-{}".format(get_random_string(5))
         # Specification for the sandbox. We will pass the spec for the forks of route and frontend services.
         request = Sandbox(
             spec=SandboxSpec(
-                description="Sample sandbox created using Python SDK",
+                description="Sample sandbox created using Python SDK (use case 2)",
                 cluster=cls.SIGNADOT_CLUSTER_NAME,
                 ttl=SandboxTTL(duration="10m"),
-                forks=[route_fork, frontend_fork]
+                forks=[route_fork, frontend_fork],
+                default_route_group=SandboxDefaultRouteGroup(
+                    endpoints=[
+                        RouteGroupSpecEndpoint(name="hotrod-frontend", target="http://frontend.hotrod.deploy:8080")
+                    ]
+                )
             )
         )
 


### PR DESCRIPTION
As of now, Node SDK release is still TBD because I haven't yet figured out the solution to [this](https://github.com/signadot/node-sdk/actions/runs/3834003521/jobs/6525975840). So, in this PR, I have updated the examples for only Java and Python SDKs.

I did get the codegen to work with v2.4.7 of swagger codegen (vs v2.4.25) that we're using. But I didn't feel like using a different version just for the JS SDK, and that too against the template of v2.4.25. I'll address the Node SDK one separately as needed.

cc: @foxish 