### PR TITLE
fix link to routegroup spec

### DIFF
--- a/cli/routegroup-all.yaml
+++ b/cli/routegroup-all.yaml
@@ -2,7 +2,7 @@
 #
 # Example yaml file containing input to the signadot cli
 # which defines a routegroup.  Further documentation
-# is available at https://docs.signadot.com/docs/routegroups-spec
+# is available at https://docs.signadot.com/docs/routegroup-spec
 
 name: my-routegroup                           # name used to identify the routegroup
 spec:


### PR DESCRIPTION
The URL to the routegroup spec was made singular, to be consistent with the sandbox spec.  This broke this URL.

I also noticed that the plural version of the link was outside our docs here https://signadotcommunity.slack.com/archives/C0404LRHD97/p1672790212043349

We may be able to redirect plural to singular, but at any rate it seems better to have it be consistent between internal references at least.

