### PR TITLE
adopt example to use new resource plugin

### DIFF
--- a/cli/sandbox-resource.yaml
+++ b/cli/sandbox-resource.yaml
@@ -17,7 +17,7 @@ spec:
       target: "http://customer.@{namespace}.deploy:8081"  # target url
   resources:                                  # resource allocated to the sandbox.
   - name: testdb                              # name of the resource.
-    plugin: sd-mariadb                        # name of the resource plugin.
+    plugin: mariadb                        # name of the resource plugin.
     params:                                   # parameters to pass to the resource plugin.
       dbname: testdb                          # a parameter is a key-value, string-string pair.
   forks:                                      # set of workloads to fork and how to fork.
@@ -31,4 +31,5 @@ spec:
         valueFrom:                            # dynamic value, determined when the fork is created.
           resource:                           # value taken from sandbox resource
             name: testdb                      # the resource is named 'testdb' in this sandbox.
-            outputKey: dbhost                 # the resource plugin provides a value for this key.
+            outputKey: provision.host         # the resource plugin provides a value for this key.
+            

--- a/cli/sandbox-resource.yaml
+++ b/cli/sandbox-resource.yaml
@@ -32,4 +32,14 @@ spec:
           resource:                           # value taken from sandbox resource
             name: testdb                      # the resource is named 'testdb' in this sandbox.
             outputKey: provision.host         # the resource plugin provides a value for this key.
+      - name: DBPORT                          # as above
+        valueFrom:
+          resource:
+            name: testdb
+            outputKey: provision.port
+      - name: DBPASSWORD                      # as above
+        valueFrom:
+          resource:
+            name: testdb
+            outputKey: provision.root-password
             

--- a/sdk/java/src/test/java/ResourcesTest.java
+++ b/sdk/java/src/test/java/ResourcesTest.java
@@ -61,13 +61,13 @@ public class ResourcesTest {
         .customizations(new SandboxCustomizations()
           .env(Arrays.asList(
               new SandboxEnvVar().name("MYSQL_HOST").valueFrom(new SandboxEnvValueFrom().resource(
-                new SandboxEnvValueFromResource().name("customerdb").outputKey("host")
+                new SandboxEnvValueFromResource().name("customerdb").outputKey("provision.host")
               )),
               new SandboxEnvVar().name("MYSQL_PORT").valueFrom(new SandboxEnvValueFrom().resource(
-                new SandboxEnvValueFromResource().name("customerdb").outputKey("port")
+                new SandboxEnvValueFromResource().name("customerdb").outputKey("provision.port")
               )),
               new SandboxEnvVar().name("MYSQL_ROOT_PASSWORD").valueFrom(new SandboxEnvValueFrom().resource(
-                new SandboxEnvValueFromResource().name("customerdb").outputKey("root_password")
+                new SandboxEnvValueFromResource().name("customerdb").outputKey("provision.root-password")
               ))
             )
           )

--- a/sdk/node/test/resources.test.js
+++ b/sdk/node/test/resources.test.js
@@ -72,13 +72,13 @@ describe('Sandbox test using resources', () => {
               SandboxEnvVar.constructFromObject({
                 name: 'MYSQL_HOST',
                 valueFrom: SandboxEnvValueFrom.constructFromObject({
-                  resource: SandboxEnvValueFromResource.constructFromObject({name: 'customerdb', outputKey: 'host'})
+                  resource: SandboxEnvValueFromResource.constructFromObject({name: 'customerdb', outputKey: 'provision.host'})
                 })
               }),
               SandboxEnvVar.constructFromObject({
                 name: 'MYSQL_PORT',
                 valueFrom: SandboxEnvValueFrom.constructFromObject({
-                  resource: SandboxEnvValueFromResource.constructFromObject({name: 'customerdb', outputKey: 'port'})
+                  resource: SandboxEnvValueFromResource.constructFromObject({name: 'customerdb', outputKey: 'provision.port'})
                 })
               }),
               SandboxEnvVar.constructFromObject({
@@ -86,7 +86,7 @@ describe('Sandbox test using resources', () => {
                 valueFrom: SandboxEnvValueFrom.constructFromObject({
                   resource: SandboxEnvValueFromResource.constructFromObject({
                     name: 'customerdb',
-                    outputKey: 'root_password'
+                    outputKey: 'provision.root-password'
                   })
                 })
               })

--- a/sdk/python/tests/integration/resources_test.py
+++ b/sdk/python/tests/integration/resources_test.py
@@ -69,19 +69,19 @@ class TestWithResources(unittest.TestCase):
                     SandboxEnvVar(
                         name="MYSQL_HOST",
                         value_from=SandboxEnvValueFrom(
-                            resource=SandboxEnvValueFromResource(name="customerdb", output_key="host")
+                            resource=SandboxEnvValueFromResource(name="customerdb", output_key="provision.host")
                         )
                     ),
                     SandboxEnvVar(
                         name="MYSQL_PORT",
                         value_from=SandboxEnvValueFrom(
-                            resource=SandboxEnvValueFromResource(name="customerdb", output_key="port")
+                            resource=SandboxEnvValueFromResource(name="customerdb", output_key="provision.port")
                         )
                     ),
                     SandboxEnvVar(
                         name="MYSQL_ROOT_PASSWORD",
                         value_from=SandboxEnvValueFrom(
-                            resource=SandboxEnvValueFromResource(name="customerdb", output_key="root_password")
+                            resource=SandboxEnvValueFromResource(name="customerdb", output_key="provision.root-password")
                         )
                     )
                 ]


### PR DESCRIPTION
Tested against staging with mariadb 

Decided to leave out the new templating examples because they aren't so useful for sandbox specs as resource plugins.

part of https://github.com/signadot/signadot/issues/3067
