### PR TITLE
Improve logging for custom-routing-with-envoy

### DIFF
--- a/experimental/custom-routing-with-envoy/k8s/envoy-config.yaml
+++ b/experimental/custom-routing-with-envoy/k8s/envoy-config.yaml
@@ -19,6 +19,14 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               codec_type: AUTO
+              access_log:
+              - name: envoy.access_loggers.file
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                  path: /dev/stdout
+                  log_format:
+                    text_format_source:
+                      inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" - routing-key=%REQ(Ot-Baggage-Sd-Routing-Key)% routed-to=%REQ(X-SD-DST-ROUTE)% response_code=%RESPONSE_CODE% bytes_received=%BYTES_RECEIVED% bytes_sent=%BYTES_SENT% duration=%DURATION% user_agent=\"%REQ(USER-AGENT)%\"\n"
               stat_prefix: ingress_http
               route_config:
                 name: local_route
@@ -70,13 +78,16 @@ data:
                               if v.workspace == rkey then
                                 local dest = v.targetIP .. ":" .. v.targetPort
                                 request_handle:headers():add("X-Host-Port", dest)
+                                request_handle:headers():add("X-SD-DST-ROUTE", dest)
                                 request_handle:logInfo("routing to: ".. dest)
+                                return
                               end
                             end
-                          else
-                            request_handle:headers():add("X-Host-Port", "127.0.0.1:80")
-                            request_handle:logInfo("routing to baseline")
                           end
+
+                          request_handle:headers():add("X-Host-Port", "127.0.0.1:80")
+                          request_handle:headers():add("X-SD-DST-ROUTE", "baseline")
+                          request_handle:logInfo("routing to baseline")
                         end
                 - name: envoy.filters.http.dynamic_forward_proxy
                   typed_config:


### PR DESCRIPTION
With these changes now `envoy` will log entries like (note the `routing-key` and `routed-to` values):

- No routing key set in the request
```
[2023-05-19 18:19:05.795][33][info][lua] [source/extensions/filters/http/lua/lua_filter.cc:918] script log: routing to baseline
[2023-05-19T18:19:05.795Z] "GET /anything HTTP/1.1" - routing-key=- routed-to=baseline response_code=200 bytes_received=0 bytes_sent=273 duration=4 user_agent="curl/7.81.0"
```

- Setting a routing key that routes to baseline
```
[2023-05-19 18:18:58.939][36][info][lua] [source/extensions/filters/http/lua/lua_filter.cc:918] script log: routing to baseline
[2023-05-19T18:18:58.938Z] "GET /anything HTTP/1.1" - routing-key=test routed-to=baseline response_code=200 bytes_received=0 bytes_sent=308 duration=3 user_agent="curl/7.81.0"
```

- Setting a routing key that routes to a fork
```
[2023-05-19 18:18:35.742][15][info][lua] [source/extensions/filters/http/lua/lua_filter.cc:918] script log: routing to: sd-httpbin-test-sandbox-httpbin-5e870f6f.httpbin.svc.cluster.local:80
[2023-05-19T18:18:35.741Z] "GET /anything HTTP/1.1" - routing-key=px6ynn8pmtt7q routed-to=sd-httpbin-test-sandbox-httpbin-5e870f6f.httpbin.svc.cluster.local:80 response_code=200 bytes_received=0 bytes_sent=582 duration=18 user_agent="curl/7.81.0"
```