### PR TITLE
Optimize kafka demo docker image + multi-arch build

### DIFF
--- a/selective-consumption-with-kafka/Dockerfile
+++ b/selective-consumption-with-kafka/Dockerfile
@@ -1,5 +1,4 @@
-# Use an official Node.js runtime as a base image
-FROM node:20
+FROM node:20 as build
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
@@ -12,6 +11,15 @@ RUN npm install
 
 # Copy the application code to the container
 COPY . .
+
+
+FROM node:20-alpine as main
+
+# Copy app from build
+COPY --from=build /usr/src/app /usr/src/app
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
 
 # Define the command to run your application
 USER node

--- a/selective-consumption-with-kafka/Makefile
+++ b/selective-consumption-with-kafka/Makefile
@@ -5,6 +5,16 @@ SHELL = /bin/sh
 build:
 	docker build -t signadot/kafka-demo:latest .
 
+build-multi-arch:
+	docker build -t signadot/kafka-demo:latest-linux-amd64 --platform linux/amd64 .
+	docker build -t signadot/kafka-demo:latest-linux-arm64 --platform linux/arm64 .
+	docker push signadot/kafka-demo:latest-linux-amd64
+	docker push signadot/kafka-demo:latest-linux-arm64
+	docker manifest create --amend signadot/kafka-demo:latest \
+		signadot/kafka-demo:latest-linux-amd64 \
+		signadot/kafka-demo:latest-linux-arm64
+	docker manifest push signadot/kafka-demo:latest
+
 k8s-all-in-one:
 	rm -f k8s/all-in-one/demo.yaml
 	for f in k8s/pieces/*.yaml; do \

--- a/selective-consumption-with-kafka/Makefile
+++ b/selective-consumption-with-kafka/Makefile
@@ -6,8 +6,10 @@ build:
 	docker build -t signadot/kafka-demo:latest .
 
 build-multi-arch:
-	docker build -t signadot/kafka-demo:latest-linux-amd64 --platform linux/amd64 .
-	docker build -t signadot/kafka-demo:latest-linux-arm64 --platform linux/arm64 .
+	docker build -t signadot/kafka-demo:latest-linux-amd64 \
+		--platform linux/amd64 --provenance false .
+	docker build -t signadot/kafka-demo:latest-linux-arm64 \
+		--platform linux/arm64 --provenance false .
 	docker push signadot/kafka-demo:latest-linux-amd64
 	docker push signadot/kafka-demo:latest-linux-arm64
 	docker manifest create --amend signadot/kafka-demo:latest \


### PR DESCRIPTION
This reduces the image size from 1.5GB to 192MB.