### PR TITLE
Fix yaml issues in examples

### DIFF
--- a/cli/job.yaml
+++ b/cli/job.yaml
@@ -6,26 +6,18 @@
 
 spec:
   namePrefix: example-job-
-
   # refers to jobrunnergroup.yaml
   runnerGroup: example-jrg
-
   script: |
     #!/bin/sh
     echo hello example job > /tmp/artifact.txt
     echo $SIGNADOT_ROUTING_KEY > /tmp/routing-key.txt
-
   # if you have a sandbox, you can specify it here 
   # and its routing key will be available in the script
   # above
   #
   # routingContext:
   #   sandbox: my-sandbox
-
   uploadArtifact:
-  - path: /tmp/artifact.txt
-  - path: /tmp/routing-key.txt
-
-
-
-
+    - path: /tmp/artifact.txt
+    - path: /tmp/routing-key.txt

--- a/cli/jobrunnergroup-ubuntu.yaml
+++ b/cli/jobrunnergroup-ubuntu.yaml
@@ -8,24 +8,22 @@ name: example-jrg
 spec:
   cluster: minikube
   image: ubuntu
-  namespace:             # empty defaults to "signadot"
-  jobTimeout: 3m         # 3 minutes
+  namespace: # empty defaults to "signadot"
+  jobTimeout: 3m # 3 minutes
   scaling:
     manual:
       desiredPods: 2
   podTemplate:
     spec:
       containers:
-      - name: main
-        env:
-        - name: EXAMPLE_HELLO
-          value: "hello from environment"
-        # this env var requires that a secret `my-secret` exists in the signadot namespace
-        # (see namespace above) with key 'xxx'.
-        - name: EXAMPLE_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: my-secret
-              key: xxx
-
-
+        - name: main
+          env:
+            - name: EXAMPLE_HELLO
+              value: "hello from environment"
+            # this env var requires that a secret `my-secret` exists in the signadot namespace
+            # (see namespace above) with key 'xxx'.
+            - name: EXAMPLE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: my-secret
+                  key: xxx

--- a/cli/routegroup-all.yaml
+++ b/cli/routegroup-all.yaml
@@ -4,18 +4,17 @@
 # which defines a routegroup.  Further documentation
 # is available at https://docs.signadot.com/docs/routegroup-spec
 
-name: my-routegroup                           # name used to identify the routegroup
+name: my-routegroup # name used to identify the routegroup
 spec:
-  description: example routegroup spec        # description
-  cluster: signadot-staging                   # cluster in which the routegroup routes
-  match:                                      # matching spec for sandbox labels
-    label:                                    # match a single label
-      key: feature                            # with key 'feature'
-      value: "*feature-x*"                    # and value glob "*feature-x*"
-  endpoints:                                  # endpoints to be made accessible from preview server 
-  - name: frontend                            # endpoint name
-    target: http://frontend.hotrod.svc:8080   # endpoint target, hostname as resolved in-cluster
-
+  description: example routegroup spec # description
+  cluster: signadot-staging # cluster in which the routegroup routes
+  match: # matching spec for sandbox labels
+    label: # match a single label
+      key: feature # with key 'feature'
+      value: "*feature-x*" # and value glob "*feature-x*"
+  endpoints: # endpoints to be made accessible from preview server 
+    - name: frontend # endpoint name
+      target: http://frontend.hotrod.svc:8080 # endpoint target, hostname as resolved in-cluster
 # matching may take other forms, to match sandboxes
 # whose labels meet all criteria, use 'all':
 #

--- a/cli/sandbox-all.yaml
+++ b/cli/sandbox-all.yaml
@@ -3,65 +3,65 @@
 #
 # Further documentation is available at https://docs.signadot.com/docs/sandbox-spec
 #
-name: "@{dev}-@{team}-feature-x-@{commit}"    # name of the sandbox
-spec:  
-  labels:                                     # labels for sandbox analytics.
-    team: "@{team}"                           # key, value
-  cluster: staging                            # cluster in which this sandbox is to reside.
-  description: "@{dev}'s work on feature-x"   # a short description
-  ttl:                                        # optional sandbox lifetime limit
-    duration: 2d                              # N<unit>, unit m: minutes, h: hours, d: days, w: weeks
-    offsetFrom: createdAt                     # what the duration is relative to (createdAt).
-  forks:                                      # set of workloads to fork and how to fork.
-  - forkOf:                                   # what to fork
-      kind: Deployment                        # K8s Kind of workload to fork (Deployment or ArgoRollout).
-      name: frontend                          # K8s name of workload to fork.
-      namespace: "@{namespace}"               # K8s namespace in which the workload to fork resides.
-    customizations:                           # how to fork the workload specified by forkOf
-      env:                                    # define environment for containers in fork.
-      - container: main                       # what container (identified by name).
-        name: DEV                             # environmental variable name.
-        value: "@{dev}"                       # environmental variable value.
-      - name: VAR                             # a variable for the (implicit) main container.
-        value: foo                            # environmental variable value.
-      - name: BACKEND_ADDR
-        valueFrom:                            # dynamic value, determined when the fork is created.
-          fork:                               # from a fork.
-            forkOf:                           # defines which fork (must exist in this sandbox).
-              kind: Deployment                # K8s kind (Deployment or ArgoRollout).
-              namespace: "@{namespace}"       # K8s namespace.
-              name: backend                   # K8s name
-            expression: "{{.Service.Host}}:{{.Service.Port}}"  # fork-creation-time expanded expression.
-      - name: DBHOST                          # environmental variable name.
-        valueFrom:                            # dynamic value, determined when the fork is created.
-          resource:                           # value taken from sandbox resource
-            name: testdb                      # the resource is named 'testdb' in this sandbox.
-            outputKey: dbhost                 # the resource plugin provides a value for this key.
-      images:
-      - container: side                       # container name.
-        image: docker-user/side-repo:tag      # docker image reference.
-      - image: docker-user/repo:tag           # docker image for (implicit) main container.
-  - forkOf:                                   # multiple forks are possible.
-      kind: Deployment
-      name: backend
-      namespace: "@{namespace}"
-  local:                                      # local workloads to run on submitter machine via CLI
-  - name: "local-route"                       # unique local workload name
-    from:                                     # baseline workload
-      kind: Deployment
-      namespace: hotrod
-      name: route
-    mappings:                                 # mappings from baseline port to local TCP addresses
-    - port: 8083                              # baseline port (containerport).
-      toLocal: "localhost:8083"               # TCP address on which running local workload listens
+name: "@{dev}-@{team}-feature-x-@{commit}" # name of the sandbox
+spec:
+  labels: # labels for sandbox analytics.
+    team: "@{team}" # key, value
+  cluster: staging # cluster in which this sandbox is to reside.
+  description: "@{dev}'s work on feature-x" # a short description
+  ttl: # optional sandbox lifetime limit
+    duration: 2d # N<unit>, unit m: minutes, h: hours, d: days, w: weeks
+    offsetFrom: createdAt # what the duration is relative to (createdAt).
+  forks: # set of workloads to fork and how to fork.
+    - forkOf: # what to fork
+        kind: Deployment # K8s Kind of workload to fork (Deployment or ArgoRollout).
+        name: frontend # K8s name of workload to fork.
+        namespace: "@{namespace}" # K8s namespace in which the workload to fork resides.
+      customizations: # how to fork the workload specified by forkOf
+        env: # define environment for containers in fork.
+          - container: main # what container (identified by name).
+            name: DEV # environmental variable name.
+            value: "@{dev}" # environmental variable value.
+          - name: VAR # a variable for the (implicit) main container.
+            value: foo # environmental variable value.
+          - name: BACKEND_ADDR
+            valueFrom: # dynamic value, determined when the fork is created.
+              fork: # from a fork.
+                forkOf: # defines which fork (must exist in this sandbox).
+                  kind: Deployment # K8s kind (Deployment or ArgoRollout).
+                  namespace: "@{namespace}" # K8s namespace.
+                  name: backend # K8s name
+                expression: "{{.Service.Host}}:{{.Service.Port}}" # fork-creation-time expanded expression.
+          - name: DBHOST # environmental variable name.
+            valueFrom: # dynamic value, determined when the fork is created.
+              resource: # value taken from sandbox resource
+                name: testdb # the resource is named 'testdb' in this sandbox.
+                outputKey: dbhost # the resource plugin provides a value for this key.
+        images:
+          - container: side # container name.
+            image: docker-user/side-repo:tag # docker image reference.
+          - image: docker-user/repo:tag # docker image for (implicit) main container.
+    - forkOf: # multiple forks are possible.
+        kind: Deployment
+        name: backend
+        namespace: "@{namespace}"
+  local: # local workloads to run on submitter machine via CLI
+    - name: "local-route" # unique local workload name
+      from: # baseline workload
+        kind: Deployment
+        namespace: hotrod
+        name: route
+      mappings: # mappings from baseline port to local TCP addresses
+        - port: 8083 # baseline port (containerport).
+          toLocal: "localhost:8083" # TCP address on which running local workload listens
   defaultRouteGroup:
     endpoints:
-    - name: test                              # host endpoint
-      target: "grpc://test.default.svc:8081"
-    - name: frontend                          # fork endpoint for frontend fork
-      target: "http://frontend.@{namespace}.deploy:8080"
-  resources:                                  # resource allocated to the sandbox.
-  - name: testdb                              # name of the resource.
-    plugin: sd-mariadb                        # name of the resource plugin.
-    params:                                   # parameters to pass to the resource plugin.
-      dbname: testdb                          # a parameter is a key-value, string-string pair.
+      - name: test # host endpoint
+        target: "grpc://test.default.svc:8081"
+      - name: frontend # fork endpoint for frontend fork
+        target: "http://frontend.@{namespace}.deploy:8080"
+  resources: # resource allocated to the sandbox.
+    - name: testdb # name of the resource.
+      plugin: sd-mariadb # name of the resource plugin.
+      params: # parameters to pass to the resource plugin.
+        dbname: testdb # a parameter is a key-value, string-string pair.

--- a/cli/sandbox-labels.yaml
+++ b/cli/sandbox-labels.yaml
@@ -14,15 +14,15 @@ spec:
   description: signadot/hotrod-staging#0
   defaultRouteGroup:
     endpoints:
-    - name: frontend-hotrod-svc
-      target: http://frontend.hotrod.svc:8080
+      - name: frontend-hotrod-svc
+        target: http://frontend.hotrod.svc:8080
   forks:
-  - customizations:
-      env:
-      - container: hotrod
-        name: first
-        value: one
-    forkOf:
-      kind: Deployment
-      name: frontend
-      namespace: hotrod
+    - customizations:
+        env:
+          - container: hotrod
+            name: first
+            value: one
+      forkOf:
+        kind: Deployment
+        name: frontend
+        namespace: hotrod

--- a/cli/sandbox-local.yaml
+++ b/cli/sandbox-local.yaml
@@ -14,18 +14,17 @@ spec:
     feature: optimize
     owner: route-team
   local:
-  - name: "local-route"
-    from:
-      kind: Deployment
-      namespace: hotrod
-      name: route
-    mappings:
-    - port: 8083
-      toLocal: "localhost:8083"
+    - name: "local-route"
+      from:
+        kind: Deployment
+        namespace: hotrod
+        name: route
+      mappings:
+        - port: 8083
+          toLocal: "localhost:8083"
   defaultRouteGroup:
-    endpoints: 
-    - name: route-endpoint
-      target: http://route.hotrod.svc:8083
-    - name: frontend-endpoint
-      target: http://frontend.hotrod.svc:8080
-
+    endpoints:
+      - name: route-endpoint
+        target: http://route.hotrod.svc:8083
+      - name: frontend-endpoint
+        target: http://frontend.hotrod.svc:8080

--- a/cli/sandbox-patch.yaml
+++ b/cli/sandbox-patch.yaml
@@ -9,25 +9,25 @@ spec:
   description: signadot/hotrod-staging#0
   defaultRouteGroup:
     endpoints:
-    - name: frontend-hotrod-svc
-      target: http://frontend.hotrod.svc:8080
+      - name: frontend-hotrod-svc
+        target: http://frontend.hotrod.svc:8080
   forks:
-  - forkOf:
-      kind: Deployment
-      name: frontend
-      namespace: hotrod
-    customizations:
-      env:
-      - container: hotrod
-        name: first
-        value: one
-      patch:
-        type: strategic # one of json, merge, strategic
-        # value can also be a string containing json
-        value: |
-          spec:
-            template:
-              spec:
-                initContainers:
-                - name: service-core-bank-migrate
-                  image: busybox
+    - forkOf:
+        kind: Deployment
+        name: frontend
+        namespace: hotrod
+      customizations:
+        env:
+          - container: hotrod
+            name: first
+            value: one
+        patch:
+          type: strategic # one of json, merge, strategic
+          # value can also be a string containing json
+          value: |
+            spec:
+              template:
+                spec:
+                  initContainers:
+                  - name: service-core-bank-migrate
+                    image: busybox

--- a/cli/sandbox-resource.yaml
+++ b/cli/sandbox-resource.yaml
@@ -7,39 +7,38 @@
 # in which the sandbox runs.  To install this resource plugin, please see
 # https://github.com/signadot/plugins/tree/main/signadot-plugins-exp/mariadb
 #
-name: "@{dev}-@{team}-x-@{commit}"    # name of the sandbox
-spec:  
-  cluster: staging                            # cluster in which this sandbox is to reside.
-  description: "@{dev}'s work on feature-x"   # a short description
+name: "@{dev}-@{team}-x-@{commit}" # name of the sandbox
+spec:
+  cluster: staging # cluster in which this sandbox is to reside.
+  description: "@{dev}'s work on feature-x" # a short description
   defaultRouteGroup:
     endpoints:
-    - name: customer                          # name of the endpoint
-      target: "http://customer.@{namespace}.deploy:8081"  # target url
-  resources:                                  # resource allocated to the sandbox.
-  - name: testdb                              # name of the resource.
-    plugin: mariadb                        # name of the resource plugin.
-    params:                                   # parameters to pass to the resource plugin.
-      dbname: testdb                          # a parameter is a key-value, string-string pair.
-  forks:                                      # set of workloads to fork and how to fork.
-  - forkOf:                                   # what to fork
-      kind: Deployment                        # K8s Kind of workload to fork (Deployment or ArgoRollout).
-      name: customer                          # K8s name of workload to fork.
-      namespace: "@{namespace}"               # K8s namespace in which the workload to fork resides.
-    customizations:                           # how to fork the workload specified by forkOf
-      env:                                    # define environment for containers in fork.
-      - name: DBHOST                          # environmental variable name.
-        valueFrom:                            # dynamic value, determined when the fork is created.
-          resource:                           # value taken from sandbox resource
-            name: testdb                      # the resource is named 'testdb' in this sandbox.
-            outputKey: provision.host         # the resource plugin provides a value for this key.
-      - name: DBPORT                          # as above
-        valueFrom:
-          resource:
-            name: testdb
-            outputKey: provision.port
-      - name: DBPASSWORD                      # as above
-        valueFrom:
-          resource:
-            name: testdb
-            outputKey: provision.root-password
-            
+      - name: customer # name of the endpoint
+        target: "http://customer.@{namespace}.deploy:8081" # target url
+  resources: # resource allocated to the sandbox.
+    - name: testdb # name of the resource.
+      plugin: mariadb # name of the resource plugin.
+      params: # parameters to pass to the resource plugin.
+        dbname: testdb # a parameter is a key-value, string-string pair.
+  forks: # set of workloads to fork and how to fork.
+    - forkOf: # what to fork
+        kind: Deployment # K8s Kind of workload to fork (Deployment or ArgoRollout).
+        name: customer # K8s name of workload to fork.
+        namespace: "@{namespace}" # K8s namespace in which the workload to fork resides.
+      customizations: # how to fork the workload specified by forkOf
+        env: # define environment for containers in fork.
+          - name: DBHOST # environmental variable name.
+            valueFrom: # dynamic value, determined when the fork is created.
+              resource: # value taken from sandbox resource
+                name: testdb # the resource is named 'testdb' in this sandbox.
+                outputKey: provision.host # the resource plugin provides a value for this key.
+          - name: DBPORT # as above
+            valueFrom:
+              resource:
+                name: testdb
+                outputKey: provision.port
+          - name: DBPASSWORD # as above
+            valueFrom:
+              resource:
+                name: testdb
+                outputKey: provision.root-password

--- a/cli/sandbox-template.yaml
+++ b/cli/sandbox-template.yaml
@@ -18,18 +18,18 @@ spec:
   labels:
     team: "@{team}"
   cluster: staging
-  description: "@{dev}'s work on feature-x" 
+  description: "@{dev}'s work on feature-x"
   defaultRouteGroup:
     endpoints:
-    - name: frontend-hotrod-svc
-      target: "http://frontend.hotrod.svc:@{port}"
+      - name: frontend-hotrod-svc
+        target: "http://frontend.hotrod.svc:@{port}"
   forks:
-  - customizations:
-      env:
-      - container: main
-        name: DEV
-        value: "@{dev}"
-    forkOf:
-      kind: Deployment
-      name: frontend
-      namespace: "@{namespace}"
+    - customizations:
+        env:
+          - container: main
+            name: DEV
+            value: "@{dev}"
+      forkOf:
+        kind: Deployment
+        name: frontend
+        namespace: "@{namespace}"

--- a/cli/sandbox-ttl.yaml
+++ b/cli/sandbox-ttl.yaml
@@ -12,12 +12,12 @@ spec:
     duration: "@{ttlDur}"
     offsetFrom: createdAt
   forks:
-  - customizations:
-      env:
-      - container: hotrod
-        name: first
-        value: one
-    forkOf:
-      kind: Deployment
-      name: frontend
-      namespace: hotrod
+    - customizations:
+        env:
+          - container: hotrod
+            name: first
+            value: one
+      forkOf:
+        kind: Deployment
+        name: frontend
+        namespace: hotrod


### PR DESCRIPTION
Ran: 

```
find ./ -name "*.yaml" -o -name "*.yml" | xargs -n 1 yq eval --inplace
```

This fixes most of the yamllint issues except "line too long (94 > 80 characters)"
It does change the YAML comments not being aligned but that seems ok to me and perhaps more readable for someone looking field by field? Curious to hear thoughts.