### PR TITLE
Add Temporal worker/client example with Signadot

### DIFF
--- a/temporal/README.md
+++ b/temporal/README.md
@@ -1,0 +1,44 @@
+# Temporal Sandbox Example
+
+This example demonstrates how to use **Temporal** workflows together with Signadot
+Sandboxes. The project contains a simple bank transfer workflow written in
+Python using the `temporalio` SDK.
+
+Two versions of the worker are provided. Version `v1` performs a transfer using
+`withdraw` and `deposit` activities. Version `v2` adds a `fraud_check`
+activity. Signadot sandboxes are used to route workflow tasks to the desired
+worker version.
+
+The `client` directory contains a small FastAPI application with a simple
+web-based form that starts a bank transfer workflow. The `worker` directories
+implement the Temporal workers.
+Routing logic is implemented via workflow and activity interceptors which query
+Signadot's RouteServer.
+
+Kubernetes manifests for deploying Temporal and the demo services are available
+in the `k8s` directory. Example sandbox specifications can be found under the
+`signadot` directory.
+
+
+## Directory Structure
+
+- `client` - FastAPI application that starts a workflow.
+- `worker` - Worker implementation with withdraw and deposit activities.
+- `worker_v2` - Worker with an additional fraud check activity.
+- `platform` - Interceptors and RouteServer client used by workers.
+- `k8s` - Kubernetes manifests for Temporal and baseline deployments.
+- `signadot` - Sandbox and routegroup specifications.
+
+## Running
+
+1. Install the Signadot operator in your Kubernetes cluster.
+2. Apply the manifests under `k8s` to deploy Temporal and baseline services.
+3. Build images for the client and workers and push them to a registry accessible
+   by the cluster.
+4. Create sandboxes using the specs in `signadot/sandboxes` and a routegroup
+   using `signadot/routegroups/temporal.yaml`.
+5. Access the client using the preview URL from the sandbox (visit `/` to use
+   the HTML form) or via the Signadot browser extension. Selecting the worker
+   sandbox in the extension will add the
+   routing key to the request. The routing interceptors ensure the workflow runs
+   on the selected worker version.

--- a/temporal/client/Dockerfile
+++ b/temporal/client/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/temporal/client/app.py
+++ b/temporal/client/app.py
@@ -1,0 +1,41 @@
+import os
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from temporalio.client import Client
+from temporalio.contrib.opentelemetry import TracingInterceptor
+
+TEMPORAL_SERVER = os.getenv("TEMPORAL_SERVER", "temporal-frontend.temporal.svc:7233")
+
+app = FastAPI()
+
+
+class TransferRequest(BaseModel):
+    from_account: str
+    to_account: str
+    amount: float
+
+
+@app.on_event("startup")
+async def startup_event():
+    app.client = await Client.connect(TEMPORAL_SERVER, interceptors=[TracingInterceptor()])
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    # serve the simple HTML form
+    path = os.path.join(os.path.dirname(__file__), "index.html")
+    return FileResponse(path)
+
+
+@app.post("/transfer")
+async def transfer(req: TransferRequest):
+    handle = await app.client.start_workflow(
+        "bank_transfer",
+        req.from_account,
+        req.to_account,
+        req.amount,
+        id=f"transfer-{req.from_account}-{req.to_account}",
+        task_queue="bank-transfer",
+    )
+    return {"workflow_id": handle.id}

--- a/temporal/client/index.html
+++ b/temporal/client/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Bank Transfer</title>
+  <meta charset="UTF-8">
+</head>
+<body>
+  <h1>Bank Transfer</h1>
+  <form id="transfer-form">
+    <label>From Account: <input type="text" id="from_account" required></label><br>
+    <label>To Account: <input type="text" id="to_account" required></label><br>
+    <label>Amount: <input type="number" id="amount" step="0.01" required></label><br>
+    <button type="submit">Transfer</button>
+  </form>
+  <script>
+    document.getElementById('transfer-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const resp = await fetch('/transfer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from_account: document.getElementById('from_account').value,
+          to_account: document.getElementById('to_account').value,
+          amount: parseFloat(document.getElementById('amount').value)
+        })
+      });
+      const data = await resp.json();
+      alert('Started workflow ' + data.workflow_id);
+    });
+  </script>
+</body>
+</html>

--- a/temporal/client/requirements.txt
+++ b/temporal/client/requirements.txt
@@ -1,0 +1,5 @@
+temporalio
+fastapi
+uvicorn
+opentelemetry-sdk
+httpx

--- a/temporal/k8s/temporal.yaml
+++ b/temporal/k8s/temporal.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: temporal-server
+  namespace: temporal-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: temporal
+  template:
+    metadata:
+      labels:
+        app: temporal
+    spec:
+      containers:
+      - name: server
+        image: temporalio/auto-setup:1.20
+        env:
+        - name: DB
+          value: "sqlite"
+        ports:
+        - containerPort: 7233
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: temporal-frontend
+  namespace: temporal-demo
+spec:
+  selector:
+    app: temporal
+  ports:
+  - port: 7233
+    targetPort: 7233
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transfer-client
+  namespace: temporal-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: transfer-client
+  template:
+    metadata:
+      labels:
+        app: transfer-client
+    spec:
+      containers:
+      - name: client
+        image: transfer-client:latest
+        ports:
+        - containerPort: 8000
+        env:
+        - name: TEMPORAL_SERVER
+          value: temporal-frontend.temporal-demo.svc:7233
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: transfer-client
+  namespace: temporal-demo
+spec:
+  selector:
+    app: transfer-client
+  ports:
+  - port: 8000
+    targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transfer-worker
+  namespace: temporal-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: transfer-worker
+  template:
+    metadata:
+      labels:
+        app: transfer-worker
+    spec:
+      containers:
+      - name: worker
+        image: transfer-worker:latest
+        env:
+        - name: TEMPORAL_SERVER
+          value: temporal-frontend.temporal-demo.svc:7233
+        - name: ROUTE_SERVER
+          value: routeserver.default.svc:3000
+        - name: SANDBOX_NAME
+          value: ""

--- a/temporal/platform/interceptors.py
+++ b/temporal/platform/interceptors.py
@@ -1,0 +1,32 @@
+from temporalio.contrib.opentelemetry import TracingInterceptor
+from temporalio.worker import WorkflowInboundInterceptor, ActivityInboundInterceptor
+from temporalio import exceptions
+from opentelemetry import baggage
+
+
+class RoutingWorkflowInterceptor(WorkflowInboundInterceptor):
+    """Interceptor that decides whether to run a workflow based on routing key."""
+
+    def __init__(self, next, router):
+        super().__init__(next)
+        self.router = router
+
+    async def execute_workflow(self, input):
+        routing_key = baggage.get_baggage("sd-routing-key") or ""
+        if not self.router.should_process(routing_key):
+            raise exceptions.ApplicationError("routing key rejected", non_retryable=True)
+        return await self.next.execute_workflow(input)
+
+
+class RoutingActivityInterceptor(ActivityInboundInterceptor):
+    """Interceptor that skips activity execution when routing key mismatches."""
+
+    def __init__(self, next, router):
+        super().__init__(next)
+        self.router = router
+
+    async def execute_activity(self, input):
+        routing_key = baggage.get_baggage("sd-routing-key") or ""
+        if not self.router.should_process(routing_key):
+            raise exceptions.ApplicationError("routing key rejected", non_retryable=True)
+        return await self.next.execute_activity(input)

--- a/temporal/platform/route_server.py
+++ b/temporal/platform/route_server.py
@@ -1,0 +1,45 @@
+import asyncio
+import httpx
+from typing import Set
+
+
+class RouteServerClient:
+    """Periodically pulls routing rules from the Signadot RouteServer."""
+
+    def __init__(self, server_addr: str, baseline_kind: str, baseline_namespace: str,
+                 baseline_name: str, sandbox_name: str = "") -> None:
+        self.server_addr = server_addr
+        self.baseline_kind = baseline_kind
+        self.baseline_namespace = baseline_namespace
+        self.baseline_name = baseline_name
+        self.sandbox_name = sandbox_name
+        self.routing_keys: Set[str] = set()
+
+    async def _pull_routes(self) -> None:
+        url = f"http://{self.server_addr}/api/v1/workloads/routing-rules"
+        params = {
+            "baselineKind": self.baseline_kind,
+            "baselineNamespace": self.baseline_namespace,
+            "baselineName": self.baseline_name,
+        }
+        if self.sandbox_name:
+            params["destinationSandboxName"] = self.sandbox_name
+        try:
+            resp = await httpx.get(url, params=params)
+            data = resp.json()
+            self.routing_keys = {
+                r["routingKey"] for r in data.get("routingRules", [])
+            }
+        except Exception as exc:
+            print(f"error contacting routeserver: {exc}")
+
+    async def run(self) -> None:
+        await self._pull_routes()
+        while True:
+            await asyncio.sleep(5)
+            await self._pull_routes()
+
+    def should_process(self, routing_key: str) -> bool:
+        if self.sandbox_name:
+            return routing_key in self.routing_keys
+        return routing_key not in self.routing_keys

--- a/temporal/signadot/routegroups/temporal.yaml
+++ b/temporal/signadot/routegroups/temporal.yaml
@@ -1,0 +1,12 @@
+name: temporal-demo
+spec:
+  cluster: "@{cluster}"
+  description: "Temporal demo client and worker sandboxes"
+  match:
+    any:
+    - label:
+        key: demo
+        value: temporal
+  endpoints:
+  - name: client
+    target: http://transfer-client.temporal-demo.svc:8000

--- a/temporal/signadot/sandboxes/client.yaml
+++ b/temporal/signadot/sandboxes/client.yaml
@@ -1,0 +1,20 @@
+name: temporal-client-sbx
+spec:
+  labels:
+    demo: "temporal"
+  cluster: "@{cluster}"
+  forks:
+  - forkOf:
+      kind: Deployment
+      name: transfer-client
+      namespace: temporal-demo
+    patches:
+    - path: spec.template.spec.containers[0].env
+      op: add
+      value:
+      - name: SANDBOX_NAME
+        value: temporal-client-sbx
+  defaultRouteGroup:
+    endpoints:
+    - name: client
+      target: http://transfer-client.temporal-demo.svc:8000

--- a/temporal/signadot/sandboxes/worker-v2.yaml
+++ b/temporal/signadot/sandboxes/worker-v2.yaml
@@ -1,0 +1,25 @@
+name: temporal-worker-v2-sbx
+spec:
+  labels:
+    demo: "temporal"
+  cluster: "@{cluster}"
+  forks:
+  - forkOf:
+      kind: Deployment
+      name: transfer-worker
+      namespace: temporal-demo
+    newName: transfer-worker-v2
+    patches:
+    - path: spec.template.spec.containers[0].env
+      op: add
+      value:
+      - name: SANDBOX_NAME
+        value: temporal-worker-v2-sbx
+      - name: WORKER_VERSION
+        value: v2
+    container: worker
+    image: transfer-worker-v2:latest
+  defaultRouteGroup:
+    endpoints:
+    - name: client
+      target: http://transfer-client.temporal-demo.svc:8000

--- a/temporal/signadot/sandboxes/worker.yaml
+++ b/temporal/signadot/sandboxes/worker.yaml
@@ -1,0 +1,20 @@
+name: temporal-worker-sbx
+spec:
+  labels:
+    demo: "temporal"
+  cluster: "@{cluster}"
+  forks:
+  - forkOf:
+      kind: Deployment
+      name: transfer-worker
+      namespace: temporal-demo
+    patches:
+    - path: spec.template.spec.containers[0].env
+      op: add
+      value:
+      - name: SANDBOX_NAME
+        value: temporal-worker-sbx
+  defaultRouteGroup:
+    endpoints:
+    - name: client
+      target: http://transfer-client.temporal-demo.svc:8000

--- a/temporal/worker/Dockerfile
+++ b/temporal/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "worker.py"]

--- a/temporal/worker/activities.py
+++ b/temporal/worker/activities.py
@@ -1,0 +1,11 @@
+from temporalio import activity
+
+
+@activity.defn
+async def withdraw(account: str, amount: float) -> None:
+    activity.logger.info(f"withdraw {amount} from {account}")
+
+
+@activity.defn
+async def deposit(account: str, amount: float) -> None:
+    activity.logger.info(f"deposit {amount} to {account}")

--- a/temporal/worker/requirements.txt
+++ b/temporal/worker/requirements.txt
@@ -1,0 +1,3 @@
+temporalio
+opentelemetry-sdk
+httpx

--- a/temporal/worker/worker.py
+++ b/temporal/worker/worker.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+from temporalio.contrib.opentelemetry import TracingInterceptor
+
+from ..platform.route_server import RouteServerClient
+from ..platform.interceptors import RoutingWorkflowInterceptor, RoutingActivityInterceptor
+from .workflow import BankTransferWorkflow
+from . import activities
+
+
+async def main() -> None:
+    server = os.getenv("TEMPORAL_SERVER", "temporal-frontend.temporal.svc:7233")
+    task_queue = os.getenv("TASK_QUEUE", "bank-transfer")
+    sandbox = os.getenv("SANDBOX_NAME", "")
+    route_server = os.getenv("ROUTE_SERVER", "routeserver.default.svc:3000")
+
+    router = RouteServerClient(route_server, "Deployment", "temporal-demo", "worker", sandbox)
+    asyncio.create_task(router.run())
+
+    client = await Client.connect(server, interceptors=[TracingInterceptor()])
+
+    worker = Worker(
+        client,
+        task_queue=task_queue,
+        workflows=[BankTransferWorkflow],
+        activities=[activities.withdraw, activities.deposit],
+        interceptors=[
+            TracingInterceptor(),
+            lambda next: RoutingWorkflowInterceptor(next, router),
+            lambda next: RoutingActivityInterceptor(next, router),
+        ],
+    )
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/temporal/worker/workflow.py
+++ b/temporal/worker/workflow.py
@@ -1,0 +1,20 @@
+from temporalio import workflow
+from . import activities
+
+
+@workflow.defn
+class BankTransferWorkflow:
+    @workflow.run
+    async def run(self, from_account: str, to_account: str, amount: float) -> None:
+        await workflow.execute_activity(
+            activities.withdraw,
+            from_account,
+            amount,
+            schedule_to_close_timeout=5,
+        )
+        await workflow.execute_activity(
+            activities.deposit,
+            to_account,
+            amount,
+            schedule_to_close_timeout=5,
+        )

--- a/temporal/worker_v2/Dockerfile
+++ b/temporal/worker_v2/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "worker.py"]

--- a/temporal/worker_v2/activities.py
+++ b/temporal/worker_v2/activities.py
@@ -1,0 +1,16 @@
+from temporalio import activity
+
+
+@activity.defn
+async def withdraw(account: str, amount: float) -> None:
+    activity.logger.info(f"withdraw {amount} from {account}")
+
+
+@activity.defn
+async def deposit(account: str, amount: float) -> None:
+    activity.logger.info(f"deposit {amount} to {account}")
+
+
+@activity.defn
+async def fraud_check(from_account: str, to_account: str, amount: float) -> None:
+    activity.logger.info(f"fraud check from {from_account} to {to_account} amount {amount}")

--- a/temporal/worker_v2/requirements.txt
+++ b/temporal/worker_v2/requirements.txt
@@ -1,0 +1,3 @@
+temporalio
+opentelemetry-sdk
+httpx

--- a/temporal/worker_v2/worker.py
+++ b/temporal/worker_v2/worker.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+from temporalio.contrib.opentelemetry import TracingInterceptor
+
+from ..platform.route_server import RouteServerClient
+from ..platform.interceptors import RoutingWorkflowInterceptor, RoutingActivityInterceptor
+from .workflow import BankTransferWorkflowV2
+from . import activities
+
+
+async def main() -> None:
+    server = os.getenv("TEMPORAL_SERVER", "temporal-frontend.temporal.svc:7233")
+    task_queue = os.getenv("TASK_QUEUE", "bank-transfer")
+    sandbox = os.getenv("SANDBOX_NAME", "")
+    route_server = os.getenv("ROUTE_SERVER", "routeserver.default.svc:3000")
+
+    router = RouteServerClient(route_server, "Deployment", "temporal-demo", "worker", sandbox)
+    asyncio.create_task(router.run())
+
+    client = await Client.connect(server, interceptors=[TracingInterceptor()])
+
+    worker = Worker(
+        client,
+        task_queue=task_queue,
+        workflows=[BankTransferWorkflowV2],
+        activities=[activities.withdraw, activities.deposit, activities.fraud_check],
+        interceptors=[
+            TracingInterceptor(),
+            lambda next: RoutingWorkflowInterceptor(next, router),
+            lambda next: RoutingActivityInterceptor(next, router),
+        ],
+    )
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/temporal/worker_v2/workflow.py
+++ b/temporal/worker_v2/workflow.py
@@ -1,0 +1,27 @@
+from temporalio import workflow
+from . import activities
+
+
+@workflow.defn
+class BankTransferWorkflowV2:
+    @workflow.run
+    async def run(self, from_account: str, to_account: str, amount: float) -> None:
+        await workflow.execute_activity(
+            activities.fraud_check,
+            from_account,
+            to_account,
+            amount,
+            schedule_to_close_timeout=5,
+        )
+        await workflow.execute_activity(
+            activities.withdraw,
+            from_account,
+            amount,
+            schedule_to_close_timeout=5,
+        )
+        await workflow.execute_activity(
+            activities.deposit,
+            to_account,
+            amount,
+            schedule_to_close_timeout=5,
+        )


### PR DESCRIPTION
## Summary
- add Temporal demo with client, workers, and sandbox specs
- include RouteServer interceptors and two worker versions
- provide HTML UI and fix baggage handling for the client

## Testing
- `python -m py_compile $(git ls-files "temporal/**/*.py")`


------
https://chatgpt.com/codex/tasks/task_b_6879489cd1788326b3f798a0b034466b